### PR TITLE
Issues/openbmc env shell aliases

### DIFF
--- a/openbmc-env
+++ b/openbmc-env
@@ -23,8 +23,8 @@ CURR_DIR=$(pwd)
 if [ -n "$TEMPLATECONF" ]; then
     platform_name=${TEMPLATECONF//\/conf/""}
     #echo "conf:$platform_name"
-    ami=$(ls -d meta-ami/meta-*)
-    evb=$(ls -d meta-evb/meta-evb-aspeed/meta*)
+    ami=$(\ls -d meta-ami/meta-*)
+    evb=$(\ls -d meta-evb/meta-evb-aspeed/meta*)
     platform_list="${ami}"$'\n'"${evb}"
 
     for temp_metaname in $platform_list; do

--- a/update-features-macro.py
+++ b/update-features-macro.py
@@ -117,8 +117,8 @@ def get_features_configs(configs):
                     if 'spx_macro' in feature.keys():
                         # print('dict Feature:',feature['spx_macro'],feature['enable'])
                         f[feature['spx_macro']] = feature['enable']
-		    elif 'macro' in feature.keys():
-			f[feature['macro']] = feature['enable']
+                    elif 'macro' in feature.keys():
+                        f[feature['macro']] = feature['enable']
                     else:
                         print("Warning, ", feature['name']," this feature is not proper")
                     if 'path' in feature.keys() and feature['path'] and feature['path'].endswith('.yaml'):
@@ -133,7 +133,7 @@ def get_features_configs(configs):
                 if 'spx_macro' in feature.keys():
                     # print('list Feature:', feature['spx_macro'], feature['enable'])
                     f[feature['spx_macro']] = feature['enable']
-		elif 'macro' in feature.keys():
+                elif 'macro' in feature.keys():
                         f[feature['macro']] = feature['enable']
                 else:
                     print("Warning, ", feature['name']," this feature is not proper")
@@ -285,10 +285,10 @@ pdh_ctnt = ''
 pdmk_ctnt = ''
 with open('projdef.cfg', 'r') as pdf:
     pdc_ctnt = pdf.read()
-for f,v in features.iteritems():
+for f,v in features.items():
     pdc_ctnt = update_prjdef_cfg(pdc_ctnt, f, v)
 
-for c,v in configs.iteritems():
+for c,v in configs.items():
     pdc_ctnt = update_prjdef_cfg(pdc_ctnt, c, v)
 
 with open('projdef.mod.cfg', 'w') as pdf:


### PR DESCRIPTION
* If user has a shell alias for `ls(1)` which alters its output (e.g. `ls -F`), then `openbmc-env` fails to generate `build/tmp/projdef.mod.cfg`. Escape the calling of `ls` so that the alias is not used.
* Recently deprecated Python2.x provides method [dict.iteritems()](https://python-reference.readthedocs.io/en/latest/docs/dict/iteritems.html) to iterate through a dictionary; it is not available in Python3.x, which uses backwards-compatible [dict.items()](https://python-reference.readthedocs.io/en/latest/docs/dict/items.html) method.

Test (Python2.x machine):
  1. Enter `alias 'ls=ls -F'`.
  2. Configure build (e.g. `TEMPLATECONF=meta-ami/meta-tiogapass/conf  . openbmc-env`).
  3. `projdef.mod.cfg` is not created without this patch.
Test (Python3.x machine):
  4. Repeat 1-3 (`python --version` returns `Python 3.x.x`).
