### PR TITLE
Patch to favor strsignal() over deprecated sys_siglist[] in groff.

### DIFF
--- a/poky/meta/recipes-extended/groff/files/0001-strsignal.patch
+++ b/poky/meta/recipes-extended/groff/files/0001-strsignal.patch
@@ -1,0 +1,30 @@
+diff -u3 -r groff-1.22.4/configure.ac groff-1.22.4.new/configure.ac
+--- groff-1.22.4/configure.ac	2018-12-18 16:13:01.000000000 -0500
++++ groff-1.22.4.new/configure.ac	2021-08-10 15:58:00.930469324 -0400
+@@ -140,6 +140,7 @@
+ LIBS="$saved_libs"
+ AC_CHECK_FUNCS([gettimeofday isatty kill rename setlocale strsep])
+ GROFF_MKSTEMP
++AC_CHECK_DECLS([strsignal, getc_unlocked])
+ AC_CHECK_DECLS([sys_siglist, getc_unlocked])
+ AM_LANGINFO_CODESET
+ 
+diff -u3 -r groff-1.22.4/src/roff/groff/pipeline.c groff-1.22.4.new/src/roff/groff/pipeline.c
+--- groff-1.22.4/src/roff/groff/pipeline.c	2018-10-10 17:44:56.000000000 -0400
++++ groff-1.22.4.new/src/roff/groff/pipeline.c	2021-08-10 15:54:16.358815148 -0400
+@@ -570,10 +570,15 @@
+   static char buf[sizeof("Signal ") + 1 + sizeof(int) * 3];
+ 
+ #ifdef NSIG
++#if HAVE_DECL_STRSIGNAL
++  if (n >= 0 && n < NSIG && strsignal(n) != 0)
++    return strsignal(n);
++#else
+ #if HAVE_DECL_SYS_SIGLIST
+   if (n >= 0 && n < NSIG && sys_siglist[n] != 0)
+     return sys_siglist[n];
+ #endif /* HAVE_DECL_SYS_SIGLIST */
++#endif /* HAVE_DECL_STRSIGNAL */
+ #endif /* NSIG */
+   sprintf(buf, "Signal %d", n);
+   return buf;

--- a/poky/meta/recipes-extended/groff/groff_1.22.4.bb
+++ b/poky/meta/recipes-extended/groff/groff_1.22.4.bb
@@ -12,7 +12,8 @@ SRC_URI = "${GNU_MIRROR}/groff/groff-${PV}.tar.gz \
 	file://groff-not-search-fonts-on-build-host.patch \
 	file://0001-support-musl.patch \
 	file://0001-Include-config.h.patch \
-        file://0001-Make-manpages-mulitlib-identical.patch \
+	file://0001-Make-manpages-mulitlib-identical.patch \
+	file://0001-strsignal.patch \
 "
 
 SRC_URI[md5sum] = "08fb04335e2f5e73f23ea4c3adbf0c5f"


### PR DESCRIPTION
On my system, groff is built with `HAVE_DECL_SYS_SIGLIST` defined, but an error occurs when compiling the symbol [sys_siglist[]](https://man7.org/linux/man-pages/man3/strsignal.3.html)`.  Patch adapted from commit [e59589a4c](https://git.savannah.gnu.org/cgit/groff.git/commit/?id=e59589a4cb7c2b5fafad36ddecf12dda92cc5b33) in the [groff git repository](https://git.savannah.gnu.org/cgit/groff.git).
